### PR TITLE
Ambiguous clause problem 

### DIFF
--- a/sqlalchemy_fulltext/__init__.py
+++ b/sqlalchemy_fulltext/__init__.py
@@ -35,12 +35,20 @@ class FullTextSearch(ClauseElement):
         self.against = literal(against)
         self.mode = mode
 
+
+def get_table_name(element):
+    if hasattr(element.model, "__table__"):
+        return "`" + element.model.__table__.fullname + "`."
+    return ""
+
+
 @compiles(FullTextSearch, MYSQL)
 def __mysql_fulltext_search(element, compiler, **kw):
     assert issubclass(element.model, FullText), "{0} not FullTextable".format(element.model)
-    return MYSQL_MATCH_AGAINST.format(", ".join(["`" + element.model.__table__.fullname + "`." + column for column in element.model.__fulltext_columns__]),
-                                      compiler.process(element.against),
-                                      element.mode)
+    return MYSQL_MATCH_AGAINST.format(
+        ", ".join([get_table_name(element) + column for column in element.model.__fulltext_columns__]),
+        compiler.process(element.against),
+        element.mode)
 
 
 class FullText(object):


### PR DESCRIPTION
I had following query causing the problem.

session.query(Product).join(Product.company).filter(Company.active == True, FullTextSearch(search_pattern, Product, FullTextMode.BOOLEAN).all()

where both Product and Company contained the FullText index for column 'description'. This was causing that the query above was ambiguous.

To fix this I have added a table name at the query generation in the function  __mysql_fulltext_search.
It is working & passing the tests at travis (thx for the hint about travis).

I am still aware that the fixed table name is not best solution as the elements can be aliased and SqlAlchemy is offering aliasing support. Still my knowledge how SA is handling the aliasing internally is not sufficient to make it better at the moment.  
