### PR TITLE
Add index_fulltext for Flask-Migrate

### DIFF
--- a/sqlalchemy_fulltext/__init__.py
+++ b/sqlalchemy_fulltext/__init__.py
@@ -94,12 +94,18 @@ class FullText(object):
     """
 
     __fulltext_after_create__ = True
+
+
+class FullTextForMigration(FullText):
+    __fulltext_after_create__ = False
+
     @classmethod
     def index_fulltext(cls):
         """
         call like Index('idx_<__tablename__>_fulltext', *__fulltext_columns__, mysql_prefix='FULLTEXT')
         """
-        cls.__fulltext_after_create__ = False
+        assert cls.__tablename__, "Model:{0.__name__} No table name defined".format(cls)
+        assert cls.__fulltext_columns__, "Model:{0.__name__} No FullText columns defined".format(cls)
         Index('idx_%s_fulltext' % cls.__tablename__,
                 *(getattr(cls, c) for c in cls.__fulltext_columns__),
                   mysql_prefix='FULLTEXT')

--- a/test_sqlalchemy_fulltext.py
+++ b/test_sqlalchemy_fulltext.py
@@ -10,6 +10,7 @@ from sqlalchemy_fulltext import FullText, FullTextSearch
 import sqlalchemy_fulltext.modes as FullTextMode
 
 FULLTEXT_TABLE = "test_full_text"
+FULLTEXT_TABLE_FOR_MIGRATION = "test_full_text_for_migration"
 BASE = declarative_base()
 
 try:
@@ -19,6 +20,7 @@ except ImportError:
 
 SESSION = sessionmaker(bind=ENGINE)()
 SESSION.execute('DROP TABLE IF EXISTS {0};'.format(FULLTEXT_TABLE))
+SESSION.execute('DROP TABLE IF EXISTS {0};'.format(FULLTEXT_TABLE_FOR_MIGRATION))
 
 MYSQL_ENGINES = [i[0] for i in SESSION.execute('SHOW ENGINES;').fetchall()
                 if i[1] == "YES"]
@@ -30,7 +32,7 @@ class RecipeReviewModel(FullText, BASE):
     # mroonga engine supporting CJK chars
     __table_args__ = {'mysql_engine':'MyISAM',
                       'mysql_charset':'utf8'}
-    
+
     __fulltext_columns__ = ('commentor','review')
 
     id        = Column(Integer,primary_key=True)
@@ -40,6 +42,27 @@ class RecipeReviewModel(FullText, BASE):
     def __init__(self, commentor, review):
         self.review = review
         self.commentor = commentor
+
+
+class RecipeReviewModelForMigration(FullText, BASE):
+    __tablename__ = FULLTEXT_TABLE_FOR_MIGRATION
+    # mroonga engine supporting CJK chars
+    __table_args__ = {'mysql_engine': 'MyISAM',
+                      'mysql_charset': 'utf8'}
+
+    __fulltext_columns__ = ('commentor', 'review')
+
+    id = Column(Integer, primary_key=True)
+    commentor = Column(String(length=100))
+    review = Column(Text())
+
+    def __init__(self, commentor, review):
+        self.review = review
+        self.commentor = commentor
+
+
+RecipeReviewModelForMigration.index_fulltext()
+
 
 class TestSQLAlchemyFullText(unittest.TestCase):
 
@@ -62,15 +85,21 @@ class TestSQLAlchemyFullText(unittest.TestCase):
                 self.entries.append(RecipeReviewModel(
                                 entry['commentor'],
                                 entry['review']))
+                self.entries.append(RecipeReviewModelForMigration(
+                                entry['commentor'],
+                                entry['review']))
 
         for entry in self.entries:
             self.assertIsNone( self.session.add(entry))
         self.session.commit()
     def test_fulltext_form_query(self):
         FullTextSearch('spam', RecipeReviewModel)
+        FullTextSearch('spam', RecipeReviewModelForMigration)
 
     def test_fulltext_query(self):
         full = self.session.query(RecipeReviewModel).filter(FullTextSearch('spam', RecipeReviewModel))
+        self.assertEqual(full.count(), 2,)
+        full = self.session.query(RecipeReviewModelForMigration).filter(FullTextSearch('spam', RecipeReviewModelForMigration))
         self.assertEqual(full.count(), 2,)
         raw = self.session.execute('SELECT * FROM {0} WHERE MATCH (commentor, review) AGAINST ("spam")'.format(RecipeReviewModel.__tablename__))
         self.assertEqual(full.count(), raw.rowcount, 'Query Test Failed')
@@ -78,24 +107,33 @@ class TestSQLAlchemyFullText(unittest.TestCase):
     def test_fulltext_qutoe_query(self):
         full = self.session.query(RecipeReviewModel).filter(FullTextSearch('"parrot can"', RecipeReviewModel, FullTextMode.BOOLEAN))
         self.assertEqual(full.count(), 2,)
+        full = self.session.query(RecipeReviewModelForMigration).filter(FullTextSearch('"parrot can"', RecipeReviewModelForMigration, FullTextMode.BOOLEAN))
+        self.assertEqual(full.count(), 2,)
         raw = self.session.execute("""SELECT * FROM {0} WHERE MATCH (commentor, review) AGAINST ('"parrot can"' IN BOOLEAN MODE)""".format(RecipeReviewModel.__tablename__))
         self.assertEqual(full.count(), raw.rowcount)
-    
+
     @unittest.skipIf(not 'mroonga' in MYSQL_ENGINES, 'mroonga engines not available')
     def test_fulltext_cjk_query(self):
         cjk = self.session.query(RecipeReviewModel).filter(
                                   FullTextSearch('中国人'.decode('utf8'),
                                                  RecipeReviewModel))
+        cjk = self.session.query(RecipeReviewModelForMigration).filter(
+                                  FullTextSearch('中国人'.decode('utf8'),
+                                                 RecipeReviewModelForMigration))
 
-    
+
     def test_fulltext_query_natural_mode(self):
         full = self.session.query(RecipeReviewModel).filter(FullTextSearch('spam', RecipeReviewModel, FullTextMode.NATURAL))
+        self.assertEqual(full.count(), 2,)
+        full = self.session.query(RecipeReviewModelForMigration).filter(FullTextSearch('spam', RecipeReviewModelForMigration, FullTextMode.NATURAL))
         self.assertEqual(full.count(), 2,)
         raw = self.session.execute('SELECT * FROM {0} WHERE MATCH (commentor, review) AGAINST ("spam" IN NATURAL LANGUAGE MODE)'.format(RecipeReviewModel.__tablename__))
         self.assertEqual(full.count(), raw.rowcount, 'Query Test Failed')
 
     def test_fulltext_query_boolean_mode(self):
         full = self.session.query(RecipeReviewModel).filter(FullTextSearch('spa*', RecipeReviewModel, FullTextMode.BOOLEAN))
+        self.assertEqual(full.count(), 3,)
+        full = self.session.query(RecipeReviewModelForMigration).filter(FullTextSearch('spa*', RecipeReviewModelForMigration, FullTextMode.BOOLEAN))
         self.assertEqual(full.count(), 3,)
         raw = self.session.execute('SELECT * FROM {0} WHERE MATCH (commentor, review) AGAINST ("spa*" IN BOOLEAN MODE)'.format(RecipeReviewModel.__tablename__))
         self.assertEqual(full.count(), raw.rowcount, 'Query Test Failed')
@@ -108,9 +146,17 @@ class TestSQLAlchemyFullText(unittest.TestCase):
         raw = self.session.execute('SELECT * FROM {0} WHERE MATCH (commentor, review) AGAINST ("the -rainbow" IN BOOLEAN MODE)'.format(RecipeReviewModel.__tablename__))
         self.assertEqual(full.count(), raw.rowcount, 'Query Test Failed')
 
+        full = self.session.query(RecipeReviewModelForMigration).filter(RecipeReviewModelForMigration.id >= 1)
+        full = full.filter(FullTextSearch('the -rainbow', RecipeReviewModelForMigration, FullTextMode.BOOLEAN)).limit(20)
+        self.assertEqual(full.count(), 0)
+        raw = self.session.execute('SELECT * FROM {0} WHERE MATCH (commentor, review) AGAINST ("the -rainbow" IN BOOLEAN MODE)'.format(RecipeReviewModelForMigration.__tablename__))
+        self.assertEqual(full.count(), raw.rowcount, 'Query Test Failed')
+
 
     def test_fulltext_query_query_expansion_mode(self):
         full = self.session.query(RecipeReviewModel).filter(FullTextSearch('spam', RecipeReviewModel, FullTextMode.QUERY_EXPANSION))
+        self.assertEqual(full.count(), 3,)
+        full = self.session.query(RecipeReviewModelForMigration).filter(FullTextSearch('spam', RecipeReviewModelForMigration, FullTextMode.QUERY_EXPANSION))
         self.assertEqual(full.count(), 3,)
         raw = self.session.execute('SELECT * FROM {0} WHERE MATCH (commentor, review) AGAINST ("spam" WITH QUERY EXPANSION)'.format(RecipeReviewModel.__tablename__))
         self.assertEqual(full.count(), raw.rowcount, 'Query Test Failed')

--- a/test_sqlalchemy_fulltext.py
+++ b/test_sqlalchemy_fulltext.py
@@ -6,7 +6,7 @@ from sqlalchemy import Column, Integer, String, Text, create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
-from sqlalchemy_fulltext import FullText, FullTextSearch
+from sqlalchemy_fulltext import FullText, FullTextSearch, FullTextForMigration
 import sqlalchemy_fulltext.modes as FullTextMode
 
 FULLTEXT_TABLE = "test_full_text"
@@ -44,7 +44,7 @@ class RecipeReviewModel(FullText, BASE):
         self.commentor = commentor
 
 
-class RecipeReviewModelForMigration(FullText, BASE):
+class RecipeReviewModelForMigration(FullTextForMigration, BASE):
     __tablename__ = FULLTEXT_TABLE_FOR_MIGRATION
     # mroonga engine supporting CJK chars
     __table_args__ = {'mysql_engine': 'MyISAM',


### PR DESCRIPTION
As #12, ALTER TABLE does not affects Flask-Migrate, so this PR offers another way with `FullTextForMigration` to add FULLTEXT INDEX (Refer [SQLAlchemy MySQL index-prefixes](http://docs.sqlalchemy.org/en/latest/dialects/mysql.html?highlight=index#index-prefixes)).

Flask-Migrate generates scripts to upgrade and downgrade including create/drop tables but does not fire any event in scripts.
This PR's way makes a script include like below:
```python
def upgrade():
    # create tables...
    op.create_index('idx_<__tablename__>_fulltext', [<__fulltext_columns__>], unique=False, mysql_prefix='FULLTEXT')
   # create tables...

def downgrade():
    # drop tables...
    op.drop_index('idx_<__tablename__>_fulltext', table_name=<__tablename__>)
   # drop tables...
```

And `show index` expresses below:
```
+------------------------------+------------+-------------------------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| Table                        | Non_unique | Key_name                                  | Seq_in_index | Column_name | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment |
+------------------------------+------------+-------------------------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| test_full_text_for_migration |          0 | PRIMARY                                   |            1 | id          | A         |          11 |     NULL | NULL   |      | BTREE      |         |               |
| test_full_text_for_migration |          1 | idx_test_full_text_for_migration_fulltext |            1 | commentor   | NULL      |        NULL |     NULL | NULL   | YES  | FULLTEXT   |         |               |
| test_full_text_for_migration |          1 | idx_test_full_text_for_migration_fulltext |            2 | review      | NULL      |        NULL |     NULL | NULL   | YES  | FULLTEXT   |         |               |
+------------------------------+------------+-------------------------------------------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
```

Feel free to close this if something inconvenient. Thank you for your library!