### PR TITLE
only build fulltext index for mysql dialect

### DIFF
--- a/sqlalchemy_fulltext/__init__.py
+++ b/sqlalchemy_fulltext/__init__.py
@@ -83,7 +83,7 @@ class FullText(object):
                      DDL(MYSQL_BUILD_INDEX_QUERY.format(cls,
                          ", ".join((escape_quote(c)
                                     for c in cls.__fulltext_columns__)))
-                         )
+                         ).execute_if(dialect=MYSQL)
                      )
     """
     TODO: black magic in the future


### PR DESCRIPTION
The DDL instructions to extend the schema only work on MySQL, so when
they are run for other database dialects they fail. This causes tests
that use databases like sqlite to fail, even if they are not using the
full text searching features. This change configures the DDL
instruction to only run when the database dialect is mysql to prevent
these failures.

Signed-off-by: Doug Hellmann <doug@doughellmann.com>